### PR TITLE
Fixes bug 298

### DIFF
--- a/.idea/other.xml
+++ b/.idea/other.xml
@@ -323,17 +323,6 @@
           <option name="screenX" value="1080" />
           <option name="screenY" value="2424" />
         </PersistentDeviceSelectionData>
-        <PersistentDeviceSelectionData>
-          <option name="api" value="29" />
-          <option name="brand" value="samsung" />
-          <option name="codename" value="x1q" />
-          <option name="id" value="x1q" />
-          <option name="manufacturer" value="Samsung" />
-          <option name="name" value="Galaxy S20" />
-          <option name="screenDensity" value="480" />
-          <option name="screenX" value="1440" />
-          <option name="screenY" value="3200" />
-        </PersistentDeviceSelectionData>
       </list>
     </option>
   </component>

--- a/app/src/main/java/com/team3663/scouting_app/activities/AppLaunch.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/AppLaunch.java
@@ -361,11 +361,17 @@ public class AppLaunch extends AppCompatActivity {
             // Default Globals
             Globals.CurrentTeamOverrideNum = 0;
 
-            // Go to the first page
-            Intent GoToPreMatch = new Intent(AppLaunch.this, PreMatch.class);
-            startActivity(GoToPreMatch);
+            if ((Globals.sp == null) ||
+                    (Globals.sp.getInt(Constants.Prefs.COMPETITION_ID, -1) == -1) ||
+                    (Globals.sp.getInt(Constants.Prefs.DEVICE_ID, -1) == -1)) {
+                Toast.makeText( AppLaunch.this,R.string.applaunch_not_configured, Toast.LENGTH_SHORT).show();
+            } else {
+                // Go to the first page
+                Intent GoToPreMatch = new Intent(AppLaunch.this, PreMatch.class);
+                startActivity(GoToPreMatch);
 
-            finish();
+                finish();
+            }
         });
     }
 }

--- a/app/src/main/res/layout/app_launch.xml
+++ b/app/src/main/res/layout/app_launch.xml
@@ -55,7 +55,7 @@
         android:textColor="@color/cpr_green"
         android:textSize="72sp"
         android:textStyle="bold"
-        android:text="@string/applanuch_scouting_app"
+        android:text="@string/applaunch_scouting_app"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/image_CPR3663"

--- a/app/src/main/res/values/strings_app_launch.xml
+++ b/app/src/main/res/values/strings_app_launch.xml
@@ -25,5 +25,6 @@
     <string name="applaunch_file_error_colors">Error loading colors from data file!</string>
 
     <string name="applaunch_start_scouting">Start Scouting</string>
-    <string name="applanuch_scouting_app">Scouting App</string>
+    <string name="applaunch_scouting_app">Scouting App</string>
+    <string name="applaunch_not_configured">This device is not configured yet.  Go to Settings to set it up.</string>
 </resources>


### PR DESCRIPTION
fixes #298

The problem was with an unconfigured device (or AVD).  In that case, we don't know the competition (hence no match data shows up) and we don't know the device id, or the team scouting (THIS is the exact issue why the achievement didn't pop, 'cause it didn't know who was scouting (it was a -1) and didn't match team 3663.)

I now check that the device is configured, and if not, post a Toast message and don't let them continue to scout.  

We could detect this early and pop them right into Settings off the bat, but they might hit "cancel" and we'd end up in a similar spot, so this just made more sense to me.