### PR TITLE
normalize X,Y to a %age of the field.

### DIFF
--- a/app/src/main/java/com/team3663/scouting_app/config/Constants.java
+++ b/app/src/main/java/com/team3663/scouting_app/config/Constants.java
@@ -61,8 +61,8 @@ public class Constants {
         public static final int BUTTON_TEXT_COLOR_DISABLED = Color.LTGRAY;
         public static final String ORIENTATION_LANDSCAPE = "l";
         public static final String ORIENTATION_LANDSCAPE_REVERSE = "lr";
-        public static int IMAGE_HEIGHT;
-        public static int IMAGE_WIDTH;
+        public static int IMAGE_HEIGHT = 0;
+        public static int IMAGE_WIDTH = 0;
     }
 
     public static class Data {

--- a/app/src/main/java/com/team3663/scouting_app/utility/Logger.java
+++ b/app/src/main/java/com/team3663/scouting_app/utility/Logger.java
@@ -218,6 +218,8 @@ public class Logger {
             LoggerEventRow ler = match_log_events.get(i);
 
             // Normalize the X, Y coordinates to be a %age of the image size
+            // Multiply the %age by 10,000 to get a whole number representing 2 digits of precision (ie: 0.3956 turns into 3956)
+            // We do this to save 2 characters in the .csv file that we need to transmit.
             int normalized_x = 0;
             int normalized_y = 0;
             if (Constants.Match.IMAGE_WIDTH > 0) normalized_x = (int)(10_000.0 * Integer.parseInt(ler.X) / Constants.Match.IMAGE_WIDTH);

--- a/app/src/main/java/com/team3663/scouting_app/utility/Logger.java
+++ b/app/src/main/java/com/team3663/scouting_app/utility/Logger.java
@@ -216,8 +216,15 @@ public class Logger {
         // Form the output line that goes in the csv file.
         for (int i = 1; i < match_log_events.size(); ++i) {
             LoggerEventRow ler = match_log_events.get(i);
+
+            // Normalize the X, Y coordinates to be a %age of the image size
+            int normalized_x = 0;
+            int normalized_y = 0;
+            if (Constants.Match.IMAGE_WIDTH > 0) normalized_x = (int)(10_000.0 * Integer.parseInt(ler.X) / Constants.Match.IMAGE_WIDTH);
+            if (Constants.Match.IMAGE_HEIGHT > 0) normalized_y = (int)(10_000.0 * Integer.parseInt(ler.Y) / Constants.Match.IMAGE_HEIGHT);
+
             String csv_line = Globals.CurrentCompetitionId + ":" + Globals.CurrentMatchNumber + ":" + Globals.CurrentDeviceId;
-            csv_line += "," + i + "," + ler.EventId + "," + ler.LogTime + "," + ler.X + "," + ler.Y + "," + ler.PrevSeq;
+            csv_line += "," + i + "," + ler.EventId + "," + ler.LogTime + "," + normalized_x + "," + normalized_y + "," + ler.PrevSeq;
             try {
                 fos_event.write(csv_line.getBytes(StandardCharsets.UTF_8));
                 fos_event.write(System.lineSeparator().getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
fixes #233 

Changed the constants to have a default value of 0.
Only needed to change the logger when we write out the data, to convert to a %age of the field size.