### PR TITLE
fix #336

### DIFF
--- a/app/src/main/assets/input_data/StartPositions.csv
+++ b/app/src/main/assets/input_data/StartPositions.csv
@@ -1,5 +1,5 @@
 ﻿StartPosition_Id,StartPosition_Active,StartPosition_Description
 0,TRUE,Did Not Play
-1,TRUE,Processor Side
-2,TRUE,Center
-3,TRUE,Far Side
+1,TRUE,Far Side
+2,TRUE,Middle
+3,TRUE,Processor Side

--- a/app/src/main/java/com/team3663/scouting_app/activities/Match.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/Match.java
@@ -648,7 +648,7 @@ public class Match extends AppCompatActivity {
             last_event_id = Globals.EventLogger.UndoLastEvent();
 
             // If there are no events left to undo, hide the button
-            if ((last_event_id == -1) || (current_event[Globals.EventList.getEventGroup(Constants.Events.ID_AUTO_START_GAME_PIECE)] == Constants.Events.ID_AUTO_START_GAME_PIECE)) {
+            if ((last_event_id == -1) || (current_event[Globals.EventList.getEventGroup(last_event_id)] == Constants.Events.ID_AUTO_START_GAME_PIECE)) {
                 // Certain actions can't be set from a non-UI thread
                 // So we need to make a Runner that will execute on the UI thread to set this.
                 Match.this.runOnUiThread(() -> {

--- a/app/src/main/java/com/team3663/scouting_app/config/Constants.java
+++ b/app/src/main/java/com/team3663/scouting_app/config/Constants.java
@@ -73,12 +73,12 @@ public class Constants {
     }
 
     public static class Events {
-        public static final int ID_DEFENDED_START = 150;
-        public static final int ID_DEFENDED_END = 151;
-        public static final int ID_DEFENSE_START = 152;
-        public static final int ID_DEFENSE_END = 153;
-        public static final int ID_NOT_MOVING_START = 154;
-        public static final int ID_NOT_MOVING_END = 155;
+        public static final int ID_DEFENDED_START = 60;
+        public static final int ID_DEFENDED_END = 61;
+        public static final int ID_DEFENSE_START = 62;
+        public static final int ID_DEFENSE_END = 63;
+        public static final int ID_NOT_MOVING_START = 64;
+        public static final int ID_NOT_MOVING_END = 65;
         public static final int ID_AUTO_START_GAME_PIECE = 0;
         public static final int ID_NO_EVENT = 999;   // use to check if the eventID you're looking for doesn't exist
     }

--- a/app/src/main/java/com/team3663/scouting_app/utility/Logger.java
+++ b/app/src/main/java/com/team3663/scouting_app/utility/Logger.java
@@ -27,6 +27,7 @@ public class Logger {
     private int seq_number_prev_common = 0; // Track previous sequence number for all common events
     private int seq_number_prev_defended = 0; // Track previous sequence number for just defended toggle
     private int seq_number_prev_defense = 0; // Track previous sequence number for just defense toggle
+    private int seq_number_prev_not_moving = 0; // Track previous sequence number for just not-moving toggle
     private final ArrayList<Pair<String, String>> match_log_data = new ArrayList<>();
     private final Context appContext;
     private final ArrayList<LoggerEventRow> match_log_events = new ArrayList<>();
@@ -269,6 +270,13 @@ public class Logger {
                 seq_number_prev = seq_number_prev_defense;
                 seq_number++;
                 break;
+            case Constants.Events.ID_NOT_MOVING_START:
+                seq_number_prev_not_moving = ++seq_number;
+                break;
+            case Constants.Events.ID_NOT_MOVING_END:
+                seq_number_prev = seq_number_prev_not_moving;
+                seq_number++;
+                break;
             default:
                 seq_number_prev = seq_number_prev_common;
                 seq_number_prev_common = ++seq_number;
@@ -384,7 +392,10 @@ public class Logger {
 
         // In order to UNDO this event, we need to find what the new last event is and return it
         // after we remove the one we need to undo.  Save off the groupId of this event for later
+        // Reset the current event for that group (we'll find it later - but this ensures that if we
+        // DON'T find it, it'll be reset properly.
         lastEventGroupId = Globals.EventList.getEventGroup(lastEventId);
+        Match.current_event[lastEventGroupId] = -1;
         match_log_events.remove(lastIndex);
 
         // For any events AFTER this removed event, we need to decrement the "PrevSeq" since they all

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.3"
+agp = "8.8.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Aug 15 18:25:19 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
First, we weren't handling "Not Moving" at all properly like the other toggles.  Added the variables for that.

Secondly, we didn't reset the current menu group's "last event" correctly if it was the last (first?) one.  So if you undo Climb->Start, we removed if from the logging, but since we didn't find a "previous" climbing event, we just left it along (as climb Start, which isn't correct).

Thirdly, checking if we have NO previous event was wrong since the 2nd part of the OR was always true.  oops.

Cleaned up starting position order (per Erica)
Cleaned up EventIDs for toggle switches (per new ranges I made for ReefScape)