### PR TITLE
fixes

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.team3663.scouting_app"
         minSdk = 30
         targetSdk = 34
-        versionCode = 15
-        versionName = "2.0.4"
+        versionCode = 16
+        versionName = "2.1.0"
 
         setProperty("archivesBaseName", "CPR-Scout-$versionName")
 

--- a/app/src/main/java/com/team3663/scouting_app/activities/PreMatch.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/PreMatch.java
@@ -396,10 +396,6 @@ public class PreMatch extends AppCompatActivity {
                         Intent GoToMatch = new Intent(PreMatch.this, Match.class);
                         startActivity(GoToMatch);
                     } else {
-                        // Increases the match number so that it auto fills for the next match correctly
-                        //  and do it after the logger is closed so that this can't mess the logger up
-                        Globals.CurrentMatchNumber++;
-
                         // Reset the Saved Start position so that you have to choose it again
                         Globals.CurrentStartPosition = 0;
 

--- a/app/src/main/java/com/team3663/scouting_app/activities/QRCode.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/QRCode.java
@@ -50,6 +50,7 @@ public class QRCode extends AppCompatActivity {
         // Initialize activity components
         InitQRData();
         InitQREvent();
+        InitBack();
         InitNext();
      }
 
@@ -62,6 +63,7 @@ public class QRCode extends AppCompatActivity {
     private void InitQREvent() {
         BarcodeEncoder be = new BarcodeEncoder();
         String qrDataEvent= Globals.CurrentCompetitionId + "_" + Globals.transmitMatchNum + "_" + Globals.CurrentDeviceId + "_e.csv" + "\n" + getFileAsString(Globals.transmitMatchNum,"e");
+
         if (qrDataEvent.length()> Constants.QRCode.MAX_QR_DATA_SIZE){
             Toast.makeText(QRCode.this, " Data file is too big for this method", Toast.LENGTH_LONG).show();
             return;
@@ -72,7 +74,6 @@ public class QRCode extends AppCompatActivity {
             qrCodeBinding.imageQREvent.setImageBitmap(bm);
         } catch (Exception e) {
             Toast.makeText(QRCode.this, "Failed to generate QR Code!", Toast.LENGTH_LONG).show();
-//            throw new RuntimeException(e);
         }
     }
 
@@ -85,6 +86,7 @@ public class QRCode extends AppCompatActivity {
     private void InitQRData() {
         BarcodeEncoder be = new BarcodeEncoder();
         String qrData= Globals.CurrentCompetitionId + "_" + Globals.transmitMatchNum + "_" + Globals.CurrentDeviceId + "_d.csv" + "\n" + getFileAsString(Globals.transmitMatchNum,"d");
+
         if (qrData.length()> Constants.QRCode.MAX_QR_DATA_SIZE){
             Toast.makeText(QRCode.this, " Data file is too big for this method", Toast.LENGTH_LONG).show();
             return;
@@ -95,8 +97,22 @@ public class QRCode extends AppCompatActivity {
             qrCodeBinding.imageQRData.setImageBitmap(bm);
         } catch (Exception e) {
             Toast.makeText(QRCode.this, "Failed to generate QR Code!", Toast.LENGTH_LONG).show();
-            throw new RuntimeException(e);
         }
+    }
+
+    // =============================================================================================
+    // Function:    InitBack
+    // Description: Initialize the Back button
+    // Parameters:  void
+    // Output:      void
+    // =============================================================================================
+    private void InitBack() {
+        qrCodeBinding.butBack.setOnClickListener(view -> {
+            Intent GoToSubmitData = new Intent(QRCode.this, SubmitData.class);
+            startActivity(GoToSubmitData);
+
+            finish();
+        });
     }
 
     // =============================================================================================

--- a/app/src/main/java/com/team3663/scouting_app/activities/SubmitData.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/SubmitData.java
@@ -51,14 +51,16 @@ public class SubmitData extends AppCompatActivity {
             return insets;
         });
 
+        // Initialize activity components that need the Logger
+        initAchievements();
+
         // We're done with the logger (only if not null - it can be null if we're resubmitting data from Pre-Match)
         if (Globals.EventLogger != null) {
             Globals.EventLogger.close();
             Globals.EventLogger = null;
         }
 
-        // Initialize activity components
-        initAchievements();
+        // Initialize activity components that don't log anything
         initMatch();
         initQR();
         initBluetooth();
@@ -88,11 +90,12 @@ public class SubmitData extends AppCompatActivity {
         if ((file_list.length == 0)) return ret;
 
         // Parse out the match number from the filename.  If this is a "d" file from the right
-        // competition (as defined in Settings) then add it to the list.
+        // competition (as defined in Settings) and matching device then add it to the list.
         for (DocumentFile df : file_list) {
             if (df.isFile() && df.getName().endsWith("d.csv")) {
                 String[] file_parts = df.getName().split("_");
-                if (Integer.parseInt(file_parts[0]) == Globals.CurrentCompetitionId)
+                if ((Integer.parseInt(file_parts[0]) == Globals.CurrentCompetitionId) &&
+                        (Integer.parseInt(file_parts[2]) == Globals.CurrentDeviceId))
                     ret_int.add(Integer.parseInt(file_parts[1]));
             }
         }

--- a/app/src/main/res/layout/qr_code.xml
+++ b/app/src/main/res/layout/qr_code.xml
@@ -7,20 +7,51 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <TextView
+        android:id="@+id/text_Heading"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:gravity="center"
+        android:text="@string/qr_heading"
+        android:textColor="@color/cpr_green"
+        android:textSize="40sp"
+        tools:ignore="TextSizeCheck" />
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/text_Heading"
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="60dp"
-            android:gravity="center"
-            android:text="@string/qr_heading"
-            android:textColor="@color/cpr_green"
-            android:textSize="50sp"
-            tools:ignore="TextSizeCheck" />
+            android:layout_height="50dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center|bottom"
+                android:textAlignment="center"
+                android:text="@string/qr_text_data"
+                android:layout_weight="1"
+                android:textColor="@color/cpr_green"
+                android:textSize="24sp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center|bottom"
+                android:textAlignment="center"
+                android:text="@string/qr_text_event"
+                android:layout_weight="1"
+                android:textColor="@color/cpr_green"
+                android:textSize="24sp" />
+
+        </LinearLayout>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="10dp"
+        android:orientation="horizontal"/>
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -41,44 +72,35 @@
                 android:layout_weight="1"
                 android:layout_gravity="center" />
         </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="65dp"
-            android:orientation="horizontal" >
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:textAlignment="center"
-                android:text="@string/qr_text_data"
-                android:layout_weight="1"
-                android:textColor="@color/cpr_green"
-                android:textSize="24sp" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:textAlignment="center"
-                android:text="@string/qr_text_event"
-                android:layout_weight="1"
-                android:textColor="@color/cpr_green"
-                android:textSize="24sp" />
-
-        </LinearLayout>
-
-        <Button
-            android:id="@+id/but_Next"
-            android:layout_width="175dp"
-            android:layout_height="60dp"
-            android:layout_marginEnd="20dp"
-            android:text="@string/qr_but_next"
-            android:textSize="24sp"
-            android:backgroundTint="@color/white"
-            android:textColor="@color/cpr_bkgnd"
-            android:layout_gravity="end"
-            tools:ignore="HardcodedText,MissingConstraints" />
     </LinearLayout>
+
+    <Button
+        android:id="@+id/but_Back"
+        android:layout_width="175dp"
+        android:layout_height="55dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginStart="20dp"
+        android:layout_marginBottom="20dp"
+        android:text="@string/qr_but_back"
+        android:textSize="24sp"
+        android:backgroundTint="@color/white"
+        android:textColor="@color/cpr_bkgnd"
+        android:layout_gravity="start"
+        tools:ignore="HardcodedText,MissingConstraints" />
+
+    <Button
+        android:id="@+id/but_Next"
+        android:layout_width="175dp"
+        android:layout_height="55dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginEnd="20dp"
+        android:layout_marginBottom="20dp"
+        android:text="@string/qr_but_next"
+        android:textSize="24sp"
+        android:backgroundTint="@color/white"
+        android:textColor="@color/cpr_bkgnd"
+        tools:ignore="HardcodedText,MissingConstraints" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings_qrcode.xml
+++ b/app/src/main/res/values/strings_qrcode.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="qr_heading">QR Code</string>
+    <string name="qr_but_back">Back</string>
     <string name="qr_but_next">Next Match</string>
     <string name="qr_text_data">Scouting Data</string>
     <string name="qr_text_event">Scouting Events</string>


### PR DESCRIPTION
fix #348
fix #346

also fixed a crash loading QR codes that are for a different device.  shouldn't happen, but can happen (especially when debugging and pushing files onto the device).  now we only show matches that also match the device id in SubmitData so that QRCodes don't crash (they used the device id in the filename to load)

see issues for more detail on the fixes.