### PR TITLE
fix if there's only one event group

### DIFF
--- a/app/src/main/java/com/team3663/scouting_app/activities/Match.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/Match.java
@@ -114,6 +114,7 @@ public class Match extends AppCompatActivity {
                 }
                 else {
                     showing_event_detail_menu = true;
+                    showing_event_detail_group = Globals.MaxEventGroups;
                     createEventContextSubMenu(in_menu);
                 }
             else if (in_v.getId() == R.id.view_ContextSubMenuView) {


### PR DESCRIPTION
if we have only one even group (like last year) i missed the line to set the submenu "group number".  it used to just exit and not show anything.  Tested it and now it works - it goes straight to the (only) submenu.

not related to a filed issue.  Just something i tested while looking at another issue (which we're not fixing right now).