### PR TITLE
fix match=0

### DIFF
--- a/app/src/main/java/com/team3663/scouting_app/activities/PreMatch.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/PreMatch.java
@@ -466,13 +466,13 @@ public class PreMatch extends AppCompatActivity {
     private void loadTeamToScout() {
         // If we have a match number load the team information for the match
         ArrayList<String> teamsInMatch = new ArrayList<>();
-        if (Globals.CurrentMatchNumber > 0) {
-            if (Globals.MatchList.isCurrentMatchValid())
-                teamsInMatch = Globals.MatchList.getListOfTeams();
-            else {
-                teamsInMatch = new ArrayList<>();
-                teamsInMatch.add(getString(R.string.pre_dropdown_no_items));
-            }
+
+        // See if this is a valid match number.  If not, default team list to "None" otherwise fill it
+        if (Globals.MatchList.isCurrentMatchValid())
+            teamsInMatch = Globals.MatchList.getListOfTeams();
+        else {
+            teamsInMatch = new ArrayList<>();
+            teamsInMatch.add(getString(R.string.pre_dropdown_no_items));
         }
 
         // If there's an override set, add it to the spinner


### PR DESCRIPTION
I don't know why we only checked for a valid match if they entered >0.  if they enter =0 (can't enter -ve values) we bypass this check and bad things happen.  The isCurrentMatchValid properly handles a match=0 so this is good to call.

tested and validated.