### PR TITLE
Add a robot starting position indicator

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.team3663.scouting_app"
         minSdk = 30
         targetSdk = 34
-        versionCode = 29
-        versionName = "2.3.5"
+        versionCode = 30
+        versionName = "2.4.0"
 
         setProperty("archivesBaseName", "CPR-Scout-$versionName")
 

--- a/app/src/main/java/com/team3663/scouting_app/activities/Match.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/Match.java
@@ -55,6 +55,8 @@ public class Match extends AppCompatActivity {
 
     // Define a Timer and TimerTasks so you can schedule things
     Timer match_Timer;
+    Timer robot_Timer;
+    TimerTask robot_timertask;
     TimerTask auto_timertask;
     TimerTask teleop_timertask;
     TimerTask gametime_timertask;
@@ -88,6 +90,7 @@ public class Match extends AppCompatActivity {
         initTime();
         initBackButton();
         initContextMenu();
+        initRobotStartLocation();
     }
 
     @Override
@@ -237,6 +240,9 @@ public class Match extends AppCompatActivity {
             OEL.disable();
         }
 
+        // Hide the starting location of the robot
+        matchBinding.textRobot.setVisibility(View.INVISIBLE);
+
         // Create the Timers and timer tasks
         match_Timer = new Timer();
         auto_timertask = new AutoTimerTask();
@@ -369,7 +375,14 @@ public class Match extends AppCompatActivity {
             match_Timer.cancel();
             match_Timer.purge();
         }
+        if (robot_Timer != null) {
+            robot_Timer.cancel();
+            robot_Timer.purge();
+        }
+
         match_Timer = null;
+        robot_Timer = null;
+        robot_timertask = null;
         auto_timertask = null;
         teleop_timertask = null;
         gametime_timertask = null;
@@ -495,6 +508,9 @@ public class Match extends AppCompatActivity {
                         matchBinding.imageFieldView.setImageDrawable(getDrawable(R.drawable.field_image_flipped));
                         currentOrientation = Constants.Match.ORIENTATION_LANDSCAPE_REVERSE;
                     }
+
+                    // Set the robot starting location based on the new rotation
+                    initRobotStartLocation();
                 }
             };
 
@@ -815,5 +831,81 @@ public class Match extends AppCompatActivity {
             matchBinding.imageFieldView.showContextMenu(current_X_Absolute, current_Y_Absolute);
             return false;
         });
+    }
+
+    // =============================================================================================
+    // Function:    initRobotStartLocation
+    // Description: Initialize the Robot starting location
+    // Parameters:  void
+    // Output:      void
+    // =============================================================================================
+    @SuppressLint("ClickableViewAccessibility")
+    private void initRobotStartLocation() {
+        robot_timertask = new RobotTimerTask();
+
+        robot_Timer = new Timer();
+        robot_Timer.schedule(robot_timertask, 250);
+    }
+
+    // =============================================================================================
+    // Class:       RobotTimerTask
+    // Description: Defines the TimerTask trigger to set the location of the robot starting position
+    // =============================================================================================
+    public class RobotTimerTask extends TimerTask {
+        @Override
+        public void run() {
+            setRobotStartLocation();
+        }
+    }
+
+    // =============================================================================================
+    // Function:    setRobotStartLocation
+    // Description: Initialize the Robot starting location
+    // Parameters:  void
+    // Output:      void
+    // =============================================================================================
+    @SuppressLint("ClickableViewAccessibility")
+    private void setRobotStartLocation() {
+        int x, y;
+        int x_offset = 30, y_offset = 15;
+        int max_x = matchBinding.imageFieldView.getWidth();
+        int max_y = matchBinding.imageFieldView.getHeight();
+        boolean blue_alliance = Globals.MatchList.getAllianceForTeam(Globals.CurrentTeamToScout).equals("BLUE");
+
+        if ((blue_alliance && currentOrientation.equals(Constants.Match.ORIENTATION_LANDSCAPE)) ||
+            (!blue_alliance && currentOrientation.equals(Constants.Match.ORIENTATION_LANDSCAPE_REVERSE)))
+        {
+            x = (max_x * 43 / 100) - x_offset;
+            switch (Globals.CurrentStartPosition) {
+                case 1:
+                    y = max_y * 25 / 100;
+                    break;
+                case 3:
+                    y = max_y * 75 / 100;
+                    break;
+                default:
+                    y = max_y / 2;
+                    break;
+            }
+        }
+        else {
+            x = max_x * 57 / 100;
+            switch (Globals.CurrentStartPosition) {
+                case 1:
+                    y = max_y * 75 / 100;
+                    break;
+                case 3:
+                    y = max_y * 25 / 100;
+                    break;
+                default:
+                    y = max_y / 2;
+                    break;
+            }
+        }
+
+        // Make sure we see the starting location of the robot
+        matchBinding.textRobot.setX(x);
+        matchBinding.textRobot.setY(y - y_offset);
+        matchBinding.textRobot.setVisibility(View.VISIBLE);
     }
 }

--- a/app/src/main/java/com/team3663/scouting_app/activities/PreMatch.java
+++ b/app/src/main/java/com/team3663/scouting_app/activities/PreMatch.java
@@ -61,6 +61,7 @@ public class PreMatch extends AppCompatActivity {
         Globals.CurrentDeviceId = Globals.sp.getInt(Constants.Prefs.DEVICE_ID, 0);
         Globals.CurrentColorId = Globals.sp.getInt(Constants.Prefs.COLOR_CONTEXT_MENU, 1);
         Globals.CurrentPrefTeamPos = Globals.sp.getInt(Constants.Prefs.PREF_TEAM_POS, 0);
+        Globals.CurrentFieldOrientationPos = Globals.sp.getInt(Constants.Prefs.PREF_ORIENTATION, 0);
 
         // Initialize activity components
         initMatchNumber();

--- a/app/src/main/java/com/team3663/scouting_app/config/Constants.java
+++ b/app/src/main/java/com/team3663/scouting_app/config/Constants.java
@@ -137,8 +137,8 @@ public class Constants {
         public static final String EVENT_TYPE_PRACTICE = "P";
         public static final String EVENT_TYPE_SEMI = "S";
         public static final String EVENT_TYPE_FINAL = "F";
-        public static final ArrayList<Integer> COMPETITION_IDS_WORLDS = new ArrayList<>(Arrays.asList(7, 8));
-        public static final ArrayList<Integer> COMPETITION_IDS_DCMP = new ArrayList<>(List.of(6));
-        public static final ArrayList<Integer> COMPETITION_IDS_EINSTEIN = new ArrayList<>(List.of(8));
+        public static final ArrayList<Integer> COMPETITION_IDS_WORLDS = new ArrayList<>(Arrays.asList(10, 11, 12, 13, 14, 15, 16, 17));
+        public static final ArrayList<Integer> COMPETITION_IDS_DCMP = new ArrayList<>(List.of(9));
+        public static final ArrayList<Integer> COMPETITION_IDS_EINSTEIN = new ArrayList<>(List.of(17));
     }
 }

--- a/app/src/main/java/com/team3663/scouting_app/data/Matches.java
+++ b/app/src/main/java/com/team3663/scouting_app/data/Matches.java
@@ -70,7 +70,28 @@ public class Matches {
         }
     }
 
-        // =============================================================================================
+    // Member Function: Return the alliance that the team is on
+    public String getAllianceForTeam(int in_Team) {
+        String ret = "";
+        String Team = String.valueOf(in_Team);
+
+        if (!this.isCurrentMatchValid()) return ret;
+        int currMatch = Globals.CurrentMatchNumber;
+
+        if (Team.equals(match_list.get(Globals.CurrentMatchType - 1).match_list_for_type.get(currMatch).blue1) ||
+                Team.equals(match_list.get(Globals.CurrentMatchType - 1).match_list_for_type.get(currMatch).blue2) ||
+                Team.equals(match_list.get(Globals.CurrentMatchType - 1).match_list_for_type.get(currMatch).blue3)) {
+
+            ret = "BLUE";
+        }
+        else {
+            ret = "RED";
+        }
+
+        return ret;
+    }
+
+    // =============================================================================================
     // Class:       MatchesForType
     // Description: Defines a structure/class to hold the information for all Matches
     // =============================================================================================

--- a/app/src/main/res/layout/match.xml
+++ b/app/src/main/res/layout/match.xml
@@ -147,6 +147,12 @@
             android:background="@color/dark_grey"
             android:layout_height="490dp">
 
+            <TextView
+                android:id="@+id/textRobot"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:background="@android:color/holo_orange_dark"/>
+
             <ImageView
                 android:id="@+id/image_FieldView"
                 android:layout_width="fill_parent"


### PR DESCRIPTION
I know i have hard-coded values.  i'm filing a clean-up bug for this.  ideally we have x,y coordinates in the StartingPositions.csv file that map to the left side of the field and mirror them for the right, but some games are mirror'd and some 180 deg flipped.  since starting positions are unique per game, i'm keeping them hard-coded since it'll all have to change next year.

delete branch when done.